### PR TITLE
Add displaying file upload errors in the top area of the form

### DIFF
--- a/app/admin/enrollments.rb
+++ b/app/admin/enrollments.rb
@@ -26,7 +26,7 @@ ActiveAdmin.register Enrollment, as: "Application" do
   scope :enrolled
 
   form do |f| # This is a formtastic form builder
-    f.semantic_errors # shows errors on :base
+    f.semantic_errors *f.object.errors.keys # shows errors on :base
     f.inputs do
      f.input :user_id, as: :select, collection: User.all
      f.input :international


### PR DESCRIPTION
I tried to upload the wrong files (big and with the wrong extension) in the admin enrollment form and noticed that errors were displayed only under the select file button and were not visible on the screen. It was not clear that the form was not saved and contained the error. So I added displaying errors at the top of the form. I hope I didn't break anything.